### PR TITLE
Forward disabled and hidden to paper-tabs

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -15,7 +15,8 @@ engines:
     enabled: true
     config:
       languages:
-        - javascript
+        javascript:
+          mass_threshold: 50
 
   fixme:
     enabled: true

--- a/cosmoz-tab.js
+++ b/cosmoz-tab.js
@@ -11,6 +11,17 @@
 			hidden: {
 				type: Boolean,
 				value: false,
+				notify: true,
+				reflectToAttribute: true,
+			},
+
+			/**
+			 *  If true, the item will be disabled.
+			 */
+			disabled: {
+				type: Boolean,
+				value: false,
+				notify: true,
 				reflectToAttribute: true,
 			},
 
@@ -20,15 +31,6 @@
 			selectable: {
 				type: String,
 				value: 'cosmoz-tab-card'
-			},
-
-			/**
-			 *  If true, the item will be disabled.
-			 */
-			disabled: {
-				type: Boolean,
-				value: false,
-				reflectToAttribute: true,
 			},
 
 			/**

--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -185,15 +185,17 @@
 		},
 
 		_itemsChanged: function (e) {
-			var mutation = e.detail;
-			mutation.addedNodes.forEach(function (item){
-				this.listen(item, 'hidden-changed', '_tabPropertyChanged');
-				this.listen(item, 'disabled-changed', '_tabPropertyChanged');
+			var mutation = e.detail,
+				handler = '_tabPropertyChanged';
+
+			mutation.addedNodes.forEach(function (nodes){
+				this.listen(nodes, 'disabled-changed', handler);
+				this.listen(nodes, 'hidden-changed', handler);
 			}, this);
 
-			mutation.removedNodes.forEach(function (item){
-				this.unlisten(item, 'hidden-changed', '_tabPropertyChanged');
-				this.unlisten(item, 'disabled-changed', '_tabPropertyChanged');
+			mutation.removedNodes.forEach(function (nodes){
+				this.unlisten(nodes, 'hidden-changed', handler);
+				this.unlisten(nodes, 'disabled-changed', handler);
 			}, this);
 		},
 

--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -50,7 +50,9 @@
 		behaviors: [
 			Cosmoz.TabbableBehavior
 		],
-
+		listeners: {
+			'iron-items-changed': '_itemsChanged'
+		},
 		observers: [
 			'_routeHashParamsChanged(_routeHashParams.*, hashParam, items)',
 			'_selectedItemChanged(selectedItem, hashParam)',
@@ -179,6 +181,29 @@
 
 			if (items.length && !selection && this.fallbackSelection === null) {
 				this.fallbackSelection = attr ? this._valueForItem(items[0]) : '0';
+			}
+		},
+
+		_itemsChanged: function (e) {
+			var mutation = e.detail;
+			mutation.addedNodes.forEach(function (item){
+				this.listen(item, 'hidden-changed', '_tabPropertyChanged');
+				this.listen(item, 'disabled-changed', '_tabPropertyChanged');
+			}, this);
+
+			mutation.removedNodes.forEach(function (item){
+				this.unlisten(item, 'hidden-changed', '_tabPropertyChanged');
+				this.unlisten(item, 'disabled-changed', '_tabPropertyChanged');
+			}, this);
+		},
+
+		_tabPropertyChanged: function (e){
+			var item = e.target,
+				index = this.items.indexOf(item),
+				property = e.type.split('-')[0];
+
+			if (index > -1 && property) {
+				this.notifyPath('items.' + index + '.' + property, e.detail.value);
 			}
 		}
 	});

--- a/test/basic.html
+++ b/test/basic.html
@@ -232,6 +232,31 @@
 						done();
 					}, 90);
 				});
+
+				test('setting hidden on cosmoz-tab updates paper-tab', function (done) {
+					var tab = tabs.items[1];
+
+					Polymer.Base.async(function (){
+						var paperTab = tabs.$$('paper-tabs').items[1];
+
+						tab.hidden = true;
+						assert.isTrue(paperTab.hidden);
+						done();
+					}, 30);
+				});
+
+				test('setting disabled on cosmoz-tab updates paper-tab', function (done) {
+					var tab = tabs.items[1];
+
+					Polymer.Base.async(function (){
+						var paperTab = tabs.$$('paper-tabs').items[1];
+
+						tab.disabled = true;
+						assert.isTrue(paperTab.disabled);
+						done();
+
+					}, 30);
+				});
 			});
 		</script>
 	</body>


### PR DESCRIPTION
On `iron-items-changed` listen/unlisten to `disabled-changed` and `hidden-changed` and notify changes on the items array.

fixes #19