### PR TITLE
selected  hidden or disbled tab should change selection to fallback

### DIFF
--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -224,6 +224,13 @@
 			}
 
 			this.notifyPath('items.' + index + '.' + property, value);
+
+			if (['hidden', 'disabled'].indexOf(property) < 0 || value !== true || this.selectedItem !== item) {
+				return;
+			}
+			this._updateInvalidSelection(item);
+		},
+
 		_updateInvalidSelection: function (selectedItem = this.selectedItem) {
 			if (!selectedItem || !selectedItem.hidden && !selectedItem.disabled || !this.fallbackSelection) {
 				return;

--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -137,7 +137,8 @@
 			var path = ['_routeHashParams', hashParam],
 				hashValue = this.get(path),
 				normalized = this._normalizeValue(hashValue),
-				invalid = this._valueToItem(normalized) == null;
+				item = this._valueToItem(normalized),
+				invalid = item == null || item.disabled || item.hidden;
 
 			if (invalid || this._normalizeValue(this.selected) === normalized) {
 				return;

--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -66,7 +66,8 @@
 		observers: [
 			'_routeHashParamsChanged(_routeHashParams.*, hashParam, items)',
 			'_selectedItemChanged(selected, hashParam)',
-			'_updateFallbackSelection(attrForSelected, items)'
+			'_updateFallbackSelection(attrForSelected, items)',
+			'_updateInvalidSelection(selectedItem)'
 		],
 
 		/**
@@ -223,6 +224,11 @@
 			}
 
 			this.notifyPath('items.' + index + '.' + property, value);
+		_updateInvalidSelection: function (selectedItem = this.selectedItem) {
+			if (!selectedItem || !selectedItem.hidden && !selectedItem.disabled || !this.fallbackSelection) {
+				return;
+			}
+			this.select(this.fallbackSelection);
 		}
 	});
 }());

--- a/test/basic.html
+++ b/test/basic.html
@@ -277,14 +277,62 @@
 					}, 30);
 				});
 
-				test('hidden tab cannot be the selected tab', function (done) {
+				test('hiding selected tab changes selection to fallbackSelection', function (done) {
 					tabs.selected = 'tab1';
-					var selectedTab = tabs.selectedItem;
-					selectedTab.hidden = true;
+					assert.equal(tabs.selectedItem, tabs.items[1]);
+					tabs.selectedItem.hidden = true;
+
+
 					Polymer.Base.async(function () {
 						var paperTab = tabs.$$('paper-tabs').items[1];
 						assert.isTrue(paperTab.hidden);
-						assert.notEqual(selectedTab, tabs.selectedItem);
+						assert.equal(tabs.selected, tabs.fallbackSelection);
+						assert.equal(tabs.selectedItem, tabs._valueToItem(tabs.fallbackSelection));
+						done();
+					}, 30);
+				});
+
+				test('selecting a hidden tab changes selection to fallbackSelection', function (done) {
+					tabs.selected = 'tab1';
+
+					assert.equal(tabs.selectedItem, tabs.items[1]);
+					assert.isTrue(tabs.items[2].hidden);
+
+					tabs.selected = 'tab2';
+
+					Polymer.Base.async(function () {
+						assert.equal(tabs.selected, tabs.fallbackSelection);
+						assert.equal(tabs.selectedItem, tabs._valueToItem(tabs.fallbackSelection));
+						done();
+					}, 30);
+				});
+
+				test('disabling selected tab changes selection to fallbackSelection', function (done) {
+					tabs.selected = 'tab1';
+
+					assert.equal(tabs.selectedItem, tabs.items[1]);
+					tabs.selectedItem.disabled = true;
+
+					Polymer.Base.async(function () {
+						var paperTab = tabs.$$('paper-tabs').items[1];
+						assert.isTrue(paperTab.disabled);
+						assert.equal(tabs.selected, tabs.fallbackSelection);
+						assert.equal(tabs.selectedItem, tabs._valueToItem(tabs.fallbackSelection));
+						done();
+					}, 30);
+				});
+
+				test('selecting a disabled tab changes selection to fallbackSelection', function (done) {
+					tabs.selected = 'tab1';
+
+					assert.equal(tabs.selectedItem, tabs.items[1]);
+					assert.isTrue(tabs.items[3].disabled);
+
+					tabs.selected = 'tab3';
+
+					Polymer.Base.async(function () {
+						assert.equal(tabs.selected, tabs.fallbackSelection);
+						assert.equal(tabs.selectedItem, tabs._valueToItem(tabs.fallbackSelection));
 						done();
 					}, 30);
 				});

--- a/test/basic.html
+++ b/test/basic.html
@@ -277,6 +277,17 @@
 					}, 30);
 				});
 
+				test('hidden tab cannot be the selected tab', function (done) {
+					tabs.selected = 'tab1';
+					var selectedTab = tabs.selectedItem;
+					selectedTab.hidden = true;
+					Polymer.Base.async(function () {
+						var paperTab = tabs.$$('paper-tabs').items[1];
+						assert.isTrue(paperTab.hidden);
+						assert.notEqual(selectedTab, tabs.selectedItem);
+						done();
+					}, 30);
+				});
 			});
 		</script>
 	</body>


### PR DESCRIPTION
Hiding or disabling selected tab should change selection to fallback.
Selecting a hidden or disabled tab should change selection to fallback.

Added tests

fixes #27 

At the moment the hash param will also change when selection is set to fallback.