### PR TITLE
Limit resize notifications

### DIFF
--- a/cosmoz-tab.js
+++ b/cosmoz-tab.js
@@ -55,8 +55,8 @@
 		},
 
 		behaviors: [
-			Cosmoz.TabbableBehavior,
-			Cosmoz.TabbedBehavior
+			Cosmoz.TabbedBehavior,
+			Cosmoz.TabbableBehavior
 		],
 
 		observers: [
@@ -104,6 +104,10 @@
 				value: value,
 				item: this
 			});
+		},
+
+		resizerShouldBeNotified(resizable) {
+			return resizable.parentNode !== this.$.header;
 		}
 
 	});

--- a/cosmoz-tabbable-behavior.html
+++ b/cosmoz-tabbable-behavior.html
@@ -219,45 +219,28 @@
 			return Boolean(this.offsetWidth || this.offsetHeight);
 		},
 
+		resizerShouldBeNotified() {
+			return true;
+		},
+
 		_onDescendantIronResize(event) {
-			if (this._notifyingDescendant || !this._isVisible) {
-				event.stopPropagation();
-				return;
-			}
-			const ev = Polymer.dom(event),
-				item =  ev.localTarget,
-				index = this.items.indexOf(item);
-
-			if (index < 0 || !item.isSelected) {
+			if (this._notifyingDescendant || !this._isVisible || !this.resizerShouldBeNotified(event.target)) {
 				event.stopPropagation();
 				return;
 			}
 
-			if (!Polymer.Settings.useShadow) {
-				this._fireResize();
-			}
-		},
-
-		resizerShouldNotify(resizable) {
-			return resizable.is === 'paper-tabs' || resizable.isSelected;
-		},
-
-		_notifyTabResize() {
-			if (!this.isAttached) {
+			if (Polymer.Settings.useShadow && event.target.domHost === this) {
 				return;
 			}
 
-			this._interestedResizables.forEach(resizable => {
-				if (this.resizerShouldNotify(resizable)) {
-					this._notifyDescendant(resizable);
-				}
-			});
-
-			if (!this._isVisible) {
-				// Fire resize on tab change only if this element is visible
-				return;
-			}
 			this._fireResize();
+		},
+
+		notifyResize() {
+			if (!this.isAttached || !this._isVisible) {
+				return;
+			}
+			Polymer.IronResizableBehavior.notifyResize.call(this);
 		}
 
 	};

--- a/cosmoz-tabbable-behavior.html
+++ b/cosmoz-tabbable-behavior.html
@@ -177,7 +177,7 @@
 				opts = {node: item, bubbles: false };
 
 			if (index > -1) {
-				this.async(this._notifyTabResize);
+				this.debounce('select-resize', this.notifyResize);
 
 				if (!item._previouslySelected) {
 					this.fire('tab-first-select', {}, opts);

--- a/cosmoz-tabbable-behavior.html
+++ b/cosmoz-tabbable-behavior.html
@@ -177,7 +177,7 @@
 				opts = {node: item, bubbles: false };
 
 			if (index > -1) {
-				this.async(this.notifyResize);
+				this.async(this._notifyTabResize);
 
 				if (!item._previouslySelected) {
 					this.fire('tab-first-select', {}, opts);
@@ -210,7 +210,56 @@
 
 		_normalizeValue: function (value) {
 			return this.attrForSelected ? value : isNaN(value) || value === null ? value : Number(value);
+		},
+
+		/**
+		* True if the current element is visible.
+		*/
+		get _isVisible() {
+			return Boolean(this.offsetWidth || this.offsetHeight);
+		},
+
+		_onDescendantIronResize(event) {
+			if (this._notifyingDescendant || !this.isVisible) {
+				event.stopPropagation();
+				return;
+			}
+			const ev = Polymer.dom(event),
+				item =  ev.localTarget,
+				index = this.items.indexOf(item);
+
+			if (index < 0 || !item.isSelected) {
+				event.stopPropagation();
+				return;
+			}
+
+			if (!Polymer.Settings.useShadow) {
+				this._fireResize();
+			}
+		},
+
+		resizerShouldNotify(resizable) {
+			return resizable.is === 'paper-tabs' || resizable.isSelected;
+		},
+
+		_notifyTabResize() {
+			if (!this.isAttached) {
+				return;
+			}
+
+			this._interestedResizables.forEach(resizable => {
+				if (this.resizerShouldNotify(resizable)) {
+					this._notifyDescendant(resizable);
+				}
+			});
+
+			if (!this.isVisible) {
+				// Fire resize on tab change only if this element is visible
+				return;
+			}
+			this._fireResize();
 		}
+
 	};
 
 	/** @polymerBehavior */

--- a/cosmoz-tabbable-behavior.html
+++ b/cosmoz-tabbable-behavior.html
@@ -220,7 +220,7 @@
 		},
 
 		_onDescendantIronResize(event) {
-			if (this._notifyingDescendant || !this.isVisible) {
+			if (this._notifyingDescendant || !this._isVisible) {
 				event.stopPropagation();
 				return;
 			}
@@ -253,7 +253,7 @@
 				}
 			});
 
-			if (!this.isVisible) {
+			if (!this._isVisible) {
 				// Fire resize on tab change only if this element is visible
 				return;
 			}

--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -245,6 +245,14 @@
 			}
 
 			event.preventDefault();
+		},
+
+		resizerShouldNotify(resizable) {
+			return resizable.is === 'paper-tabs' || resizable.isSelected;
+		},
+
+		resizerShouldBeNotified(resizable) {
+			return this.items.indexOf(resizable) > -1 && resizable.isSelected;
 		}
 	});
 }());


### PR DESCRIPTION
Limit resize notifications to selected tab and check for visible before firing a resize.

fixes #30 