### PR TITLE
Depend on items on _selectedItemChanged

### DIFF
--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -146,7 +146,7 @@
 		 * @return {void}
 		 */
 		_selectedItemChanged: function (selected, hashParam) {
-			if (!(hashParam && this._routeHashParams)) {
+			if (!(hashParam && this._routeHashParams && this.items.length)) {
 				return;
 			}
 			const item = this._valueToItem(selected),


### PR DESCRIPTION
Depend on `items` on _selectedItemChanged.
Fixes #35
Fixes a issue in 2.x where items are set async from an observer