### PR TITLE
Read hash params only once

### DIFF
--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -123,9 +123,10 @@
 		 * @return {void}
 		 */
 		_routeHashParamsChanged: function (changes, hashParam, items) {
-			if (!(changes && hashParam && items.length)) {
+			if (!(changes && hashParam && items.length) || this._hashReady) {
 				return;
 			}
+			this._hashReady = true;
 			const value = this._normalizeValue(this.get(['_routeHashParams', hashParam])),
 				item = this._valueToItem(value),
 				invalid = item == null;
@@ -146,7 +147,7 @@
 		 * @return {void}
 		 */
 		_selectedItemChanged: function (selected, hashParam) {
-			if (!(hashParam && this._routeHashParams && this.items.length)) {
+			if (!(hashParam && this._routeHashParams && this.items.length) || !this._hashReady) {
 				return;
 			}
 			const item = this._valueToItem(selected),

--- a/test/hash.html
+++ b/test/hash.html
@@ -48,13 +48,22 @@
 
 				test('updates selected item from location hash', function (done) {
 					Polymer.Base.async(function () {
+						tabs._hashReady = false; // ignore hash read in test setup to test selected update
 						window.location.hash = '##tab=tab0';
 						Polymer.Base.async(function () {
+							assert.isTrue(tabs._hashReady);
 							assert.equal(tabs._routeHashParams[tabs.hashParam], 'tab0');
 							assert.equal(tabs.selected, 'tab0');
 							assert.equal(tabs.selectedItem, tabs.items[0]);
-							window.location.hash = '#';
-							done();
+
+							window.location.hash = '##tab=tab1';
+							Polymer.Base.async(function () {
+								assert.equal(tabs._routeHashParams[tabs.hashParam], 'tab1', 'Expected _routeHashParams to be updated from location hash');
+								assert.equal(tabs.selected, 'tab0', 'Expected selected to remain tab0 as selected was already updated once from hash.');
+								assert.equal(tabs.selectedItem, tabs.items[0]);
+								window.location.hash = '#';
+								done();
+							}, 90);
 						}, 90);
 					}, 90);
 				});
@@ -66,7 +75,13 @@
 						Polymer.Base.async(function () {
 							assert.equal(tabs._routeHashParams[tabs.hashParam], 'tab1');
 							assert.equal(window.location.hash, '##tab=tab1');
-							done();
+
+							tabs.selected = 'tab0';
+							Polymer.Base.async(function () {
+								assert.equal(tabs._routeHashParams[tabs.hashParam], 'tab0');
+								assert.equal(window.location.hash, '##tab=tab0');
+								done();
+							}, 90);
 						}, 90);
 					}, 90);
 				});


### PR DESCRIPTION
fixes https://github.com/Neovici/cosmoz-tabs/issues/38
test for read hash params only once; test for selected updates location hash second time also.