### PR TITLE
19731 - Design changes in mobile mode

### DIFF
--- a/cosmoz-tab-card.html
+++ b/cosmoz-tab-card.html
@@ -66,6 +66,7 @@ Custom property | Description | Default
 				overflow: hidden;
 				transform: translate3d(0,0,0);
 				backface-visibility: hidden;
+				border-bottom: 1px solid #e2e2e2;
 			}
 
 			:host([accordion]:not([is-selected]):not([animating])) #content {
@@ -86,6 +87,7 @@ Custom property | Description | Default
 				border-bottom: 1px solid #e2e2e2;
 				cursor: pointer;
 				@apply --cosmoz-tab-card-header-accordion;
+				padding-left: 30px;
 			}
 
 			:host([accordion][is-selected]) #header {
@@ -120,8 +122,6 @@ Custom property | Description | Default
 
 		<paper-material id="card" elevation="[[ elevation ]]">
 			<div id="header" on-tap="_onToggleTap">
-				<iron-icon class="icon" icon="[[ getIcon(isSelected, accordion, icon, selectedIcon) ]]"
-					style$="[[ getIconStyle(iconColor) ]]" hidden$="[[ !accordion ]]"></iron-icon>
 				<h1 class="heading">[[ heading ]]</h1>
 				<slot name="card-actions"></slot>
 				<paper-icon-button class="button" hidden$="[[ !accordion ]]" icon$="{{ _computeOpenedIcon(isSelected) }}"></paper-icon-button>

--- a/cosmoz-tab.html
+++ b/cosmoz-tab.html
@@ -54,8 +54,7 @@ Custom property | Description | Default
 				pointer-events: none;
 			}
 			/* do not display tab header when in accordion mode and using cards */
-			:host(:not([accordion])) > #header,
-			:host([accordion][has-cards]) > #header {
+			:host(:not([accordion])) > #header {
 				display: none;
 			}
 
@@ -94,7 +93,8 @@ Custom property | Description | Default
 			}
 
 			:host([accordion]) .heading {
-				font-weight: 400;
+				font-weight: 500;
+				margin-left: 30px;
 			}
 
 			:host(:not([accordion])[is-selected]) .heading {
@@ -133,7 +133,7 @@ Custom property | Description | Default
 				backface-visibility: hidden;
 			}
 
-			:host(:not([has-cards])[accordion]:not([is-selected]):not([animating])) #content {
+			:host(:not([is-selected]):not([animating])) #content {
 				display: none;
 			}
 
@@ -147,7 +147,6 @@ Custom property | Description | Default
 			Otherwise, the tab header is rendered by cosmoz-tabs using paper-tabs
 			-->
 		<div id="header" on-tap="_onToggleTap">
-			<iron-icon class="icon" icon="[[ getIcon(isSelected, accordion, icon, selectedIcon) ]]" style$="[[ getIconStyle(iconColor) ]]"></iron-icon>
 			<h1 class="heading">[[ heading ]]</h1>
 			<div class="badge" hidden$="[[ !badge ]]" title$="[[ badge ]]">[[ badge ]]</div>
 			<paper-icon-button icon="[[ _computeOpenedIcon(isSelected) ]]"></paper-icon-button>

--- a/test/cards.html
+++ b/test/cards.html
@@ -115,7 +115,7 @@
 					const tab = tabs.items[0],
 						style = window.getComputedStyle(tab.$.header),
 						display = style.getPropertyValue('display');
-					assert.equal(display, 'none');
+					assert.equal(display, 'flex');
 				});
 
 				test('in accordion mode selected cards are opened', () => {


### PR DESCRIPTION
Design changes in mobile mode as requested in #19731.

Testing, please see https://github.com/Neovici/cosmoz-frontend/pull/600.

Instructions to get this to next as requested in the related `cosmoz-frontend` branch:
In the next branch, open `bower.json` and replace `"cosmoz-tabs": "neovici/cosmoz-tabs#^..."` with `"cosmoz-bottom-bar": "neovici/cosmoz-bottom-bar#19731-1"` (instructions made up from https://github.com/Neovici/cosmoz-bottom-bar/pull/32#issuecomment-468634684).