### PR TITLE
20827 - Setting paper-font-common-base to override font-family

### DIFF
--- a/cosmoz-tab-card.html
+++ b/cosmoz-tab-card.html
@@ -105,6 +105,7 @@ Custom property | Description | Default
 
 			.heading {
 				font-family: sans-serif;
+				@apply --paper-font-common-base;
 				font-size: 17px;
 				font-weight: 400;
 				@apply --layout-flex;

--- a/cosmoz-tab.html
+++ b/cosmoz-tab.html
@@ -82,6 +82,7 @@ Custom property | Description | Default
 
 			.heading {
 				font-family: sans-serif;
+				@apply --paper-font-common-base;
 				font-size: 17px;
 				font-weight: 300;
 				text-overflow: ellipsis;

--- a/cosmoz-tabs.html
+++ b/cosmoz-tabs.html
@@ -43,6 +43,7 @@ Custom property | Description | Default
 
 			.heading {
 				font-family: sans-serif;
+				@apply --paper-font-common-base;
 				font-size: 1.14em;
 				font-weight: 300;
 				text-overflow: ellipsis;


### PR DESCRIPTION
This overrides the font-family with paper-font-common-base, which seems to be the common practice to be able to control the font from the outside.

Testing: Connect to cosmoz-frontend, change the font-family in `--paper-font-common-base` for the theme.

Issue is Redmine 20827.