### PR TITLE
(minor) read location hash only when cosmoz-tabs becomes visible

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
 		"web-component-tester": "^6.5.0",
 		"iron-list": "PolymerElements/iron-list#^2.0.0",
 		"web-animations-js": "web-animations/web-animations-js#^2.2",
-		"webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
+		"webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
+		"iron-collapse": "PolymerElements/iron-collapse#2.2.1"
 	}
 }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -3,6 +3,9 @@
 		"mocha": true
 	},
 	"plugins": ["mocha"],
+	"parserOptions": {
+		"ecmaVersion": 8
+	},
 	"globals": {
 		"a11ySuite": false,
 		"assert": false,

--- a/test/hash-spec.html
+++ b/test/hash-spec.html
@@ -1,0 +1,277 @@
+<!doctype html>
+<html>
+	<head>
+		<title>cosmoz-tabs-hash</title>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+
+		<script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../web-component-tester/browser.js"></script>
+		<script src="../../test-fixture/test-fixture-mocha.js"></script>
+
+		<link rel="import" href="../../test-fixture/test-fixture.html">
+		<link rel="import" href="../../iron-test-helpers/iron-test-helpers.html">
+		<link rel="import" href="../../iron-collapse/iron-collapse.html">
+		<link rel="import" href="../cosmoz-tabs.html">
+		<link rel="import" href="./helpers/upgrade-dom-templates.html">
+	</head>
+	<body>
+		<test-fixture id="basic">
+			<template is="dom-template">
+				<iron-collapse opened="[[visible]]" no-animation>
+					<cosmoz-tabs id="tabs" selected="tab0" hash-param="[[hashParam]]">
+						<cosmoz-tab name="tab0">Tab text 0</cosmoz-tab>
+						<cosmoz-tab name="tab1">Tab text 1</cosmoz-tab>
+						<cosmoz-tab name="tab2">Tab text 2</cosmoz-tab>
+					</cosmoz-tabs>
+				</iron-collapse>
+			</template>
+		</test-fixture>
+
+		<script type="text/javascript">
+			const createFixture = (id, data) => new Promise(resolve => {
+				const el = fixture(id, data);
+				setTimeout(() => resolve(el));
+			});
+
+			describe('hash param behavior spec', () => {
+				before(() => {
+					window.upgradeDomTemplates();
+				});
+
+				context('when <cosmoz-tabs> is visible at creation time', () => {
+					context('and hash-param is not set', () => {
+						it('displays the correct tab', async () => {
+							// given that the page loads with a hash param value set to the last tab
+							window.location.hash = '##tab=tab2';
+
+							// when the element is created
+							// and hash-param is not set
+							const container = await createFixture('basic', {hashParam: undefined, visible: true});
+
+							// then the hash is ignored and first tab is selected
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 0');
+						});
+
+						it('reads the hash when the hash-param property is first set', async () => {
+							// given that the page loads with a hash param value set to the last tab
+							window.location.hash = '##tab=tab2';
+
+							// when the element is created
+							// and hash-param is not set
+							const container = await createFixture('basic', {hashParam: undefined, visible: true});
+
+							// then the hash is ignored and first tab is selected
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 0');
+
+							// when hash-param is updated
+							window.updateModel(container, {hashParam: 'tab'});
+
+							// then the hash is read and the correct tab is displayed
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+						});
+
+						it('ignores further changes to the hash-param property', async () => {
+							// given that the page loads with multiple hash param values
+							window.location.hash = '##tab=tab2&tabx=tab1';
+
+							// when the element is created
+							// and hash-param is not set
+							const container = await createFixture('basic', {hashParam: undefined, visible: true});
+
+							// then the hash is ignored and first tab is selected
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 0');
+
+							// when hash-param is updated
+							window.updateModel(container, {hashParam: 'tab'});
+
+							// then the hash is read and the correct tab is displayed
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+
+							// and further changes are ignored
+							window.updateModel(container, {hashParam: 'tabx'});
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+
+							window.updateModel(container, {hashParam: undefined});
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+						});
+					});
+
+					context('and hash-param is set', () => {
+						it('displays the correct tab', async () => {
+							// given that the page loads with a hash param value set to the last tab
+							window.location.hash = '##tab=tab2';
+
+							// when the element is created
+							const container = await createFixture('basic', {hashParam: 'tab', visible: true});
+
+							// then the last tab is selected
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+						});
+
+						it('displays the first tab if the hash param value is not set', async () => {
+							// given that the page loads without a hash param
+							window.location.hash = '#';
+
+							// when the element is created
+							const container = await createFixture('basic', {hashParam: 'tab', visible: true});
+
+							// then the first tab is selected
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 0');
+						});
+
+						it('ignores further hash param value changes', async () => {
+							// given that the page loads with a hash param value set to the last tab
+							window.location.hash = '##tab=tab2';
+
+							// when the element is created
+							const container = await createFixture('basic', {hashParam: 'tab', visible: true});
+
+							// then the last tab is selected
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+
+							// when the hash param is changed to the first tab
+							window.location.hash = '##tab=tab1';
+
+							// then the last tab remains selected
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+						});
+
+						it('ignores changes to the hash-param property', async () => {
+							// given that the page loads with multiple hash param values
+							window.location.hash = '##tab=tab2&tabx=tab1';
+
+							// when the element is created
+							// and hash-param is set to 'tab
+							const container = await createFixture('basic', {hashParam: 'tab', visible: true});
+
+							// then the correct tab is selected
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+
+							// when hash-param is changed
+							window.updateModel(container, {hashParam: 'tabx'});
+
+							// then the change is ignored
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+						});
+					});
+				});
+
+				context('when <cosmoz-tabs> is not visible at creation time', () => {
+					it('displays the correct tab', async () => {
+						// given that the page loads with a hash param value set to the last tab
+						window.location.hash = '##tab=tab2';
+
+						// when the element is created, but is not visible
+						const container = await createFixture('basic', {hashParam: 'tab', visible: false});
+
+						// when the element becomes visible
+						window.updateModel(container, {visible: true});
+
+						// then the last tab is selected
+						expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+					});
+
+					it('uses the current hash param value', async () => {
+						// given that the page loads with a hash param value set to the last tab
+						window.location.hash = '##tab=tab2';
+
+						// when the element is created, but is not visible
+						const container = await createFixture('basic', {hashParam: 'tab', visible: false});
+
+						// and the hash param is changed to the second tab
+						window.location.hash = '##tab=tab1';
+
+						// when the element becomes visible
+						window.updateModel(container, {visible: true});
+
+						// then the second tab is selected
+						expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 1');
+					});
+
+					it('ignores further hash param value changes', async () => {
+						// given that the page loads with a hash param value set to the last tab
+						window.location.hash = '##tab=tab2';
+
+						// when the element is created, but is not visible
+						const container = await createFixture('basic', {hashParam: 'tab', visible: false});
+
+						// when the element becomes visible
+						window.updateModel(container, {visible: true});
+
+						// then the last tab is selected
+						expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+
+						// when the hash param is changed to the first tab
+						window.location.hash = '##tab=tab1';
+
+						// and the element becomes invisible, then visible again
+						window.updateModel(container, {visible: false});
+						window.updateModel(container, {visible: true});
+
+						// then the last tab remains selected
+						expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+
+						// when the hash param is changed to the first tab
+						window.location.hash = '##tab=tab0';
+
+						// and the element becomes invisible, then visible again
+						window.updateModel(container, {visible: false});
+						window.updateModel(container, {visible: true});
+
+						// then the last tab still remains selected
+						expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 2');
+					});
+
+					it('ignores changes to the hash-param property after the first visibility change', async () => {
+						// given that the page loads with multiple hash param values: 'tab' and 'tabx'
+						window.location.hash = '##tab=tab2&tabx=tab1';
+
+						// when the element is created
+						// and hash-param is set to 'tab'
+						// and the element is not visible
+						const container = await createFixture('basic', {hashParam: 'tab', visible: false});
+
+						// when the hash-param is updated to 'tabx'
+						window.updateModel(container, {hashParam: 'tabx'});
+
+						// and the element becomes visible
+						window.updateModel(container, {visible: true});
+
+						// then the value specified by 'tabx' is selected
+						expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 1');
+
+						// when hash-param is changed to 'tab'
+						window.updateModel(container, {hashParam: 'tab'});
+
+						// then the change is ignored
+						expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 1');
+
+						// when the element becomes invisible, then visible again
+						window.updateModel(container, {visible: false});
+						window.updateModel(container, {visible: true});
+
+						// then the change is still ignored
+						expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 1');
+					});
+
+					context('if the hashParam tab is invalid', () => {
+						it('displays the fallback tab', async () => {
+							// given that the page loads with a hash param value set to an invalid tab
+							window.location.hash = '##tab=invalidtab';
+
+							// when the element is created, but is not visible
+							const container = await createFixture('basic', {hashParam: 'tab', visible: false});
+
+							// when the element becomes visible
+							window.updateModel(container, {visible: true});
+
+							// then the last tab is selected
+							expect(container.querySelector('.cosmoz-selected').innerText).to.equal('Tab text 0');
+						});
+					});
+				});
+			});
+		</script>
+	</body>
+</html>

--- a/test/helpers/upgrade-dom-templates.html
+++ b/test/helpers/upgrade-dom-templates.html
@@ -1,0 +1,20 @@
+<link rel="import" href="../../../polymer/lib/utils/templatize.html">
+
+<script type="text/javascript">
+// @see https://github.com/PolymerElements/test-fixture/issues/47#issuecomment-453212161
+// Helper code to make <template is="dom-template"> stampable by test-fixture
+window.upgradeDomTemplates = () => {
+	document.querySelectorAll('[is="dom-template"]').forEach(t => {
+		t.stamp = function (...args) {
+			if (!this._ctor) {
+				this._ctor =  Polymer.Templatize.templatize(this);
+			}
+			return new this._ctor(...args);
+		};
+	});
+};
+
+window.updateModel = (fixture, model) => {
+	fixture.__templatizeInstance.setProperties(model);
+};
+</script>

--- a/test/index.html
+++ b/test/index.html
@@ -11,6 +11,7 @@
 				'basic.html',
 				'accordion.html',
 				'hash.html',
+				'hash-spec.html',
 				'cards.html',
 				'sizing.html',
 				'fallback-selection.html',


### PR DESCRIPTION
Fixes Neovici/cosmoz-frontend#1047