### PR TITLE
(patch) notifyResize in an animation frame

### DIFF
--- a/cosmoz-tabbable-behavior.html
+++ b/cosmoz-tabbable-behavior.html
@@ -10,8 +10,7 @@
 	window.Cosmoz = window.Cosmoz || {};
 	const {
 		Debouncer,
-		Async,
-		enqueueDebouncer
+		Async
 	} = Polymer;
 
 	/**
@@ -110,6 +109,10 @@
 			this.removeEventListener('cosmoz-tab-toggle', this._onToggleTabHandler);
 			this.removeEventListener('iron-select', this._onIronSelectHandler);
 			this.removeEventListener('tab-activate', this._onTabActivateHandler);
+			if (this._debouncer != null) {
+				this._debouncer.cancel();
+				this._debouncer = null;
+			}
 		},
 
 		/**
@@ -210,10 +213,10 @@
 				detail: {}
 			};
 
-			enqueueDebouncer(this._debouncer = Debouncer.debounce(this._debouncer,
-				Async.microTask,
+			this._debouncer = Debouncer.debounce(this._debouncer,
+				Async.animationFrame,
 				this.notifyResize.bind(this)
-			));
+			);
 
 			if (!item.isActive) {
 				item.dispatchEvent(new CustomEvent('tab-first-select', eventOpts));

--- a/test/sizing.html
+++ b/test/sizing.html
@@ -210,6 +210,7 @@
 
 						tabs.selected = 'tab0';
 						Polymer.flush();
+						tabs._debouncer.flush();
 
 						list.removeEventListener('iron-resize', onResize);
 						expect(list.getBoundingClientRect().height).to.equal(349);


### PR DESCRIPTION
@nomego this is related to the forced layouts after tab changes.
The forced layouts are triggered by the `isVisible` checks (which call `offsetWidth`). We cannot do away with the `isVisible` check altogether, because it is the only reliable way to know that the element is actually rendered and visible to the user.
This update moves the resize notification to the animation frame queue, instead of the microtask queue. This should result in smoother renders, even though the layout is still forced.