### PR TITLE
ci: repo upgrades

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -2,33 +2,23 @@
 version: "2"
 checks:
   argument-count:
-    enabled: true
-    config:
-      threshold: 4
+    enabled: false  # handled by eslint rule "max-params"
   complex-logic:
     enabled: true
     config:
       threshold: 4
   file-lines:
-    enabled: true
-    config:
-      threshold: 250
+    enabled: false  # handled by eslint rule "max-lines"
   method-complexity:
-    enabled: true
-    config:
-      threshold: 5
+    enabled: false  # handled by eslint rule "complexity"
   method-count:
     enabled: true
     config:
       threshold: 20
   method-lines:
-    enabled: true
-    config:
-      threshold: 30
+    enabled: false  # handled by eslint rule "max-lines-per-function"
   nested-control-flow:
-    enabled: true
-    config:
-      threshold: 4
+    enabled: false  # handled by eslint rule "max-depth"
   return-statements:
     enabled: true
     config:
@@ -39,17 +29,9 @@ checks:
     enabled: true
 
 plugins:
-  eslint:
-    enabled: true
-    channel: "eslint-5"
-    config:
-      sanitize_batch: false
-      extensions:
-        - .js
-        - .html
   fixme:
     enabled: true
+
 exclude_patterns:
-  - "**/bower_components/"
   - "**/node_modules/"
   - "coverage/"

--- a/.github/karma-problem-matcher.json
+++ b/.github/karma-problem-matcher.json
@@ -1,0 +1,30 @@
+{
+    "problemMatcher": [{
+        "owner": "karma-eval",
+        "pattern": [{
+            "regexp": "^\\w+\\s\\d+\\.\\d+\\.\\d+\\s\\(\\w+\\s\\d+\\.\\d+\\.\\d+\\)\\sERROR$"
+        }, {
+            "regexp": "^\\s{2}(.*)$",
+            "message": 1
+        }, {
+            "regexp": "^\\s{2}at\\s([^:]*):(\\d+):(\\d+)$",
+            "file": 1,
+            "line": 2,
+            "column": 3
+        }]
+    }, {
+        "owner": "karma-test-error",
+        "pattern": [{
+            "regexp": "^\\w+\\s\\d+\\.\\d+\\.\\d+\\s\\(\\w+\\s\\d+\\.\\d+\\.\\d+\\)\\s(.*)FAILED$",
+            "code": 1
+        }, {
+            "regexp": "^\\t(.*)$",
+            "message": 1
+        }, {
+            "regexp": "^\\t {4}at\\s[^\\s]*\\s\\(([^:]*):(\\d+):(\\d+)\\)$",
+            "file": 1,
+            "line": 2,
+            "column": 3
+        }]
+    }]
+}

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,10 +14,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
 
-    - name: Use Node.js 10.x
+    - name: Use Node.js 12.x
       uses: actions/setup-node@v1
       with:
-        node-version: 10.x
+        node-version: 12.x
 
     - name: Install
       run: npm ci
@@ -26,9 +26,7 @@ jobs:
       run: npx commitlint --from origin/master --to HEAD
 
     - name: ESLint
-      run: npx github-actions-eslint-annotator
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: npm run lint
 
     - name: Test and report
       env:
@@ -42,7 +40,8 @@ jobs:
       run: |
         ([[ -e $NEO_CC ]] || curl -L $NEO_CC_URL > $NEO_CC) && chmod +x $NEO_CC
         $NEO_CC before-build
-        npm run test $([ -z "$SAUCE_ACCESS_KEY"] && echo "-- --skip-plugin sauce")
+        echo "::add-matcher::.github/karma-problem-matcher.json"
+        npm test
         $NEO_CC after-build --exit-code $?
 
     - name: Semantic release

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,9 +57,9 @@
 			},
 			"dependencies": {
 				"@babel/generator": {
-					"version": "7.9.3",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.3.tgz",
-					"integrity": "sha512-RpxM252EYsz9qLUIq6F7YJyK1sv0wWDBFuztfDGWaQKzHjqDHysxSiRUpA/X9jmfqo+WzkAVKFaUily5h+gDCQ==",
+					"version": "7.9.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
+					"integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
 					"dev": true,
 					"requires": {
 						"@babel/types": "^7.9.0",
@@ -69,9 +69,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.9.3",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.3.tgz",
-					"integrity": "sha512-E6SpIDJZ0cZAKoCNk+qSDd0ChfTnpiJN9FfNf3RZ20dzwA2vL2oq5IX1XTVT+4vDmRlta2nGk5HGMMskJAR+4A==",
+					"version": "7.9.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
 					"dev": true
 				},
 				"@babel/traverse": {
@@ -367,9 +367,9 @@
 			},
 			"dependencies": {
 				"@babel/generator": {
-					"version": "7.9.3",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.3.tgz",
-					"integrity": "sha512-RpxM252EYsz9qLUIq6F7YJyK1sv0wWDBFuztfDGWaQKzHjqDHysxSiRUpA/X9jmfqo+WzkAVKFaUily5h+gDCQ==",
+					"version": "7.9.4",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
+					"integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
 					"dev": true,
 					"requires": {
 						"@babel/types": "^7.9.0",
@@ -379,9 +379,9 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.9.3",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.3.tgz",
-					"integrity": "sha512-E6SpIDJZ0cZAKoCNk+qSDd0ChfTnpiJN9FfNf3RZ20dzwA2vL2oq5IX1XTVT+4vDmRlta2nGk5HGMMskJAR+4A==",
+					"version": "7.9.4",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+					"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
 					"dev": true
 				},
 				"@babel/traverse": {
@@ -1303,14 +1303,14 @@
 			}
 		},
 		"@neovici/cosmoz-page-router": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-page-router/-/cosmoz-page-router-6.0.1.tgz",
-			"integrity": "sha512-Ua0eYhukOyoSSms2I08HTJILs69BKBsXKVhjI2IxTNghlOQwXvWdufHS0IXKmlDvs0CXAx4LHOg1/b1/ka9Egw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/@neovici/cosmoz-page-router/-/cosmoz-page-router-6.0.3.tgz",
+			"integrity": "sha512-jLAxOmXy1LMGNDmmqO7HD5s+NKbqelP+rfyFC+93lafzUdWdS3awSWCgy7YOVwTHw5/Wjo4tAkpCOk9x9PfOrw==",
 			"requires": {
 				"@polymer/iron-location": "^3.0.0",
 				"@polymer/polymer": "^3.3.1",
 				"haunted": "^4.7.0",
-				"lit-html": "^1.1.2"
+				"lit-html": "^1.2.1"
 			}
 		},
 		"@neovici/eslint-config": {
@@ -1376,15 +1376,6 @@
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 					"dev": true
 				}
-			}
-		},
-		"@neovici/github-actions-eslint-annotator": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/@neovici/github-actions-eslint-annotator/-/github-actions-eslint-annotator-0.4.0.tgz",
-			"integrity": "sha512-+shjKgFwBW5joR/5BgJQvLi+yx40tr28VSfRHVaBQFnzzZVlOkljB37J3OmzLgxm8XpxBey42duwn9a9rwRy0w==",
-			"dev": true,
-			"requires": {
-				"eslint": ">=5"
 			}
 		},
 		"@nodelib/fs.scandir": {
@@ -1543,12 +1534,12 @@
 			}
 		},
 		"@open-wc/building-utils": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.16.0.tgz",
-			"integrity": "sha512-vhU65I0lq3/FMmu1yQL2Q8RFQ8ElLP0Trlwn267sdvA+XKJ2TV5ulHGwVggizVnS6f8O1cu2jLUdmK2SmznsYg==",
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.16.1.tgz",
+			"integrity": "sha512-0nUktFyelvSbCc8+T4w4PCyIy3i8blOFS0/EiG5xbVJ0HejDPQLTSmRBpZkn6X57tHhwUfjIdv0EAQuo2sbHEw==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.8.3",
+				"@babel/core": "^7.9.0",
 				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
 				"@webcomponents/shadycss": "^1.9.4",
 				"@webcomponents/webcomponentsjs": "^2.4.0",
@@ -1624,16 +1615,16 @@
 			}
 		},
 		"@open-wc/karma-esm": {
-			"version": "2.13.19",
-			"resolved": "https://registry.npmjs.org/@open-wc/karma-esm/-/karma-esm-2.13.19.tgz",
-			"integrity": "sha512-Cdo3WACwt5HFDgBymKSPig6A6L0g7Y+7j4k5Nha8Mg1hZRpolF+XPknaMSOWJIq0CrV2N9U96cpqitrBFbDdUA==",
+			"version": "2.13.21",
+			"resolved": "https://registry.npmjs.org/@open-wc/karma-esm/-/karma-esm-2.13.21.tgz",
+			"integrity": "sha512-qJREvj5HbYpUb6IeQXXiylPtqSnknUhBeK3PmhlnVdsXCeuPucmKJHbInd8ThYjX5/UJSp/cWe/Dt4H8GqHPHw==",
 			"dev": true,
 			"requires": {
-				"@open-wc/building-utils": "^2.16.0",
+				"@open-wc/building-utils": "^2.16.1",
 				"babel-plugin-istanbul": "^5.1.4",
 				"chokidar": "^3.0.0",
 				"deepmerge": "^3.2.0",
-				"es-dev-server": "^1.45.2",
+				"es-dev-server": "^1.46.0",
 				"minimatch": "^3.0.4",
 				"node-fetch": "^2.6.0",
 				"portfinder": "^1.0.21",
@@ -1681,12 +1672,12 @@
 			"dev": true
 		},
 		"@open-wc/testing-karma": {
-			"version": "3.3.8",
-			"resolved": "https://registry.npmjs.org/@open-wc/testing-karma/-/testing-karma-3.3.8.tgz",
-			"integrity": "sha512-3cnQapvnNV7y+2/+XLb+sf7+kVSZRWHGNxO/kwGYCJ1iO+6h8Jt0Rvy4kmRPQwT2fmVf/l0Ugj/GqbsB62DVSg==",
+			"version": "3.3.10",
+			"resolved": "https://registry.npmjs.org/@open-wc/testing-karma/-/testing-karma-3.3.10.tgz",
+			"integrity": "sha512-Z9u6EArfyQPVLmWqa//3uyu4hMF1GYVN+RFUMItAmH13ttpcufj7sxDQBh3hT2dSRsJd3iUpvLr+cCaIBqENxw==",
 			"dev": true,
 			"requires": {
-				"@open-wc/karma-esm": "^2.13.19",
+				"@open-wc/karma-esm": "^2.13.21",
 				"axe-core": "^3.3.1",
 				"karma": "^4.1.0",
 				"karma-chrome-launcher": "^3.1.0",
@@ -2224,27 +2215,44 @@
 			}
 		},
 		"@semantic-release/changelog": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-5.0.0.tgz",
-			"integrity": "sha512-A1uKqWtQG4WX9Vh4QI5b2ddhqx1qAJFlbow8szSNiXn+TaJg15LSUA9NVqyu0VxQFy3hKUJYwbBHGRXCxCy2fg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/@semantic-release/changelog/-/changelog-5.0.1.tgz",
+			"integrity": "sha512-unvqHo5jk4dvAf2nZ3aw4imrlwQ2I50eVVvq9D47Qc3R+keNqepx1vDYwkjF8guFXnOYaYcR28yrZWno1hFbiw==",
 			"dev": true,
 			"requires": {
 				"@semantic-release/error": "^2.1.0",
 				"aggregate-error": "^3.0.0",
-				"fs-extra": "^8.0.0",
+				"fs-extra": "^9.0.0",
 				"lodash": "^4.17.4"
 			},
 			"dependencies": {
 				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"version": "9.0.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.0.tgz",
+					"integrity": "sha512-pmEYSk3vYsG/bF651KPUXZ+hvjpgWYw/Gc7W9NFUe3ZVLczKKWIij3IKpOrQcdw4TILtibFslZ0UmR8Vvzig4g==",
 					"dev": true,
 					"requires": {
+						"at-least-node": "^1.0.0",
 						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
+						"jsonfile": "^6.0.1",
+						"universalify": "^1.0.0"
 					}
+				},
+				"jsonfile": {
+					"version": "6.0.1",
+					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+					"integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+					"dev": true,
+					"requires": {
+						"graceful-fs": "^4.1.6",
+						"universalify": "^1.0.0"
+					}
+				},
+				"universalify": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+					"integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+					"dev": true
 				}
 			}
 		},
@@ -2956,6 +2964,12 @@
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
 			"dev": true
 		},
+		"at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"dev": true
+		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -3397,9 +3411,9 @@
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001035",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001035.tgz",
-			"integrity": "sha512-C1ZxgkuA4/bUEdMbU5WrGY4+UhMFFiXrgNAfxiMIqWgFTWfv/xsZCS2xEHT2LMq7xAZfuAnu6mcqyDl0ZR6wLQ==",
+			"version": "1.0.30001038",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001038.tgz",
+			"integrity": "sha512-zii9quPo96XfOiRD4TrfYGs+QsGZpb2cGiMAzPjtf/hpFgB6zCPZgJb7I1+EATeMw/o+lG8FyRAnI+CWStHcaQ==",
 			"dev": true
 		},
 		"cardinal": {
@@ -4306,9 +4320,9 @@
 			"dev": true
 		},
 		"electron-to-chromium": {
-			"version": "1.3.380",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.380.tgz",
-			"integrity": "sha512-2jhQxJKcjcSpVOQm0NAfuLq8o+130blrcawoumdXT6411xG/xIAOyZodO/y7WTaYlz/NHe3sCCAe/cJLnDsqTw==",
+			"version": "1.3.387",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.387.tgz",
+			"integrity": "sha512-jjQ6WkxrOu0rtGqY9/74Z+UEVQ7YmJU2rCX6kH4eidKP0ZK0VKB3/i1avXQ+EDwJAABKGaOAbJrcyz18P8E3aA==",
 			"dev": true
 		},
 		"emoji-regex": {
@@ -4469,23 +4483,23 @@
 			}
 		},
 		"es-dev-server": {
-			"version": "1.45.2",
-			"resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.45.2.tgz",
-			"integrity": "sha512-GvpFAUnI2Rn0273gQXOkUPYKRVpfdR8EHW0QKbFQO6It2QwrNwBzDthgGGuwh1LOLCCIi0a6aLenwFEKtv2pGw==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/es-dev-server/-/es-dev-server-1.46.0.tgz",
+			"integrity": "sha512-+6RDz/YeBEkEHcf84I2pS+JYY1ov3d24JAda8hVMFQtpI21+G4/t0YA3lZSIYlPZ6AIoTgmb/+pKQh6JzmOUVA==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.8.3",
+				"@babel/core": "^7.9.0",
 				"@babel/plugin-proposal-dynamic-import": "^7.8.3",
 				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-proposal-optional-chaining": "^7.8.3",
+				"@babel/plugin-proposal-optional-chaining": "^7.9.0",
 				"@babel/plugin-syntax-class-properties": "^7.8.3",
 				"@babel/plugin-syntax-import-meta": "^7.8.3",
 				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
 				"@babel/plugin-syntax-numeric-separator": "^7.8.3",
 				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
 				"@babel/plugin-transform-template-literals": "^7.8.3",
-				"@babel/preset-env": "^7.8.3",
-				"@open-wc/building-utils": "^2.16.0",
+				"@babel/preset-env": "^7.9.0",
+				"@open-wc/building-utils": "^2.16.1",
 				"@rollup/plugin-node-resolve": "^6.1.0",
 				"@rollup/pluginutils": "^3.0.0",
 				"@types/minimatch": "^3.0.3",
@@ -4513,7 +4527,7 @@
 				"opn": "^5.4.0",
 				"parse5": "^5.1.1",
 				"path-is-inside": "^1.0.2",
-				"polyfills-loader": "^1.5.1",
+				"polyfills-loader": "^1.5.2",
 				"portfinder": "^1.0.21",
 				"strip-ansi": "^5.2.0",
 				"systemjs": "^4.0.0",
@@ -5812,9 +5826,9 @@
 			"dev": true
 		},
 		"html-escaper": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.1.tgz",
-			"integrity": "sha512-hNX23TjWwD3q56HpWjUHOKj1+4KKlnjv9PcmBUYKVpga+2cnb9nDx/B1o0yO4n+RZXZdiNxzx6B24C9aNMTkkQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+			"integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
 			"dev": true
 		},
 		"html-minifier": {
@@ -11814,13 +11828,13 @@
 			}
 		},
 		"polyfills-loader": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.5.1.tgz",
-			"integrity": "sha512-HIFEn/SggO+RHVLySvM8jIVqXu7p5VG67vDNHWagd0y8CGoqCzE57Nq1XuuJ2pHKcS82tkfOA/LRPBLZjgLd4g==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/polyfills-loader/-/polyfills-loader-1.5.2.tgz",
+			"integrity": "sha512-bcv8Id4Ylae0eSmnlMpKfba36TNr1Mh7uMGN4OEIspHLGR5/IBGSBteQp/NpbZ45T7UWQuTBvVJNQCS16E1N4A==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.8.3",
-				"@open-wc/building-utils": "^2.16.0",
+				"@babel/core": "^7.9.0",
+				"@open-wc/building-utils": "^2.16.1",
 				"@webcomponents/webcomponentsjs": "^2.4.0",
 				"abortcontroller-polyfill": "^1.4.0",
 				"core-js-bundle": "^3.6.0",
@@ -11913,9 +11927,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-			"integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
 			"dev": true
 		},
 		"pump": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
 	"version": "3.1.1",
 	"description": "A multi views container element that allow navigation between the views using tabs or an accordion.",
 	"keywords": [
-		"polymer",
 		"web-components"
 	],
 	"homepage": "https://github.com/neovici/cosmoz-tabs#readme",
@@ -15,7 +14,7 @@
 		"url": "git+https://github.com/neovici/cosmoz-tabs.git"
 	},
 	"license": "Apache-2.0",
-	"author": "",
+	"author": "Neovici Development <dev@neovici.se>",
 	"main": "cosmoz-tabs.js",
 	"directories": {
 		"test": "test"
@@ -57,7 +56,7 @@
 		}
 	},
 	"dependencies": {
-		"@neovici/cosmoz-page-router": "^6.0.1",
+		"@neovici/cosmoz-page-router": "^6.0.3",
 		"@polymer/iron-flex-layout": "^3.0.0",
 		"@polymer/iron-icon": "^3.0.0",
 		"@polymer/iron-icons": "^3.0.0",
@@ -73,9 +72,8 @@
 		"@commitlint/cli": "^8.3.5",
 		"@commitlint/config-conventional": "^8.3.4",
 		"@neovici/eslint-config": "^1.2.0",
-		"@neovici/github-actions-eslint-annotator": "^0.4.0",
 		"@open-wc/testing": "^2.5.8",
-		"@open-wc/testing-karma": "^3.3.8",
+		"@open-wc/testing-karma": "^3.3.10",
 		"@polymer/iron-collapse": "^3.0.0",
 		"@polymer/iron-component-page": "^4.0.0",
 		"@polymer/iron-demo-helpers": "^3.0.0",
@@ -85,11 +83,13 @@
 		"@polymer/paper-item": "^3.0.0",
 		"@polymer/paper-listbox": "^3.0.0",
 		"@polymer/paper-toggle-button": "^3.0.0",
-		"@semantic-release/changelog": "^5.0.0",
+		"@semantic-release/changelog": "^5.0.1",
 		"@semantic-release/git": "^9.0.0",
+		"babel-eslint": "^10.1.0",
 		"deepmerge": "^4.2.2",
-		"es-dev-server": "^1.45.2",
+		"es-dev-server": "^1.46.0",
 		"eslint": "^6.8.0",
+		"eslint-plugin-import": "^2.20.1",
 		"husky": "^4.2.3",
 		"karma": "^4.4.1",
 		"karma-firefox-launcher": "^1.3.0",


### PR DESCRIPTION
- codeclimate
  - eslint-6
  - drop .html linting, bower_components
- karma problem matcher
- setup-node
  - eslint problem matcher
  - v12.x
- drop github-actions-eslint-annotator

Signed-off-by: Patrik Kullman <patrik.kullman@neovici.se>