### PR TITLE
fix: adding after-title slot

### DIFF
--- a/cosmoz-tab-card.js
+++ b/cosmoz-tab-card.js
@@ -130,7 +130,7 @@ class CosmozTabCard extends mixinBehaviors(TabbedBehavior, PolymerElement) {
 			<div id="header" on-tap="_onToggleTap">
 				<iron-icon class="icon" icon="[[ getIcon(isSelected, accordion, icon, selectedIcon) ]]"
 					style$="[[ getIconStyle(iconColor) ]]" hidden$="[[ !accordion ]]"></iron-icon>
-				<h1 class="heading">[[ heading ]]</h1>
+				<h1 class="heading">[[ heading ]]<slot name="after-title"></slot></h1>
 				<slot name="card-actions"></slot>
 				<paper-icon-button class="button" hidden$="[[ !accordion ]]" icon$="{{ _computeOpenedIcon(isSelected) }}"></paper-icon-button>
 			</div>


### PR DESCRIPTION
Check that the slot does not impact the regular use and that the use of the slot adds content behind the title.

Redmine #23850.
