### PR TITLE
feat(hash-param): always update the selected tab when the hash param …

### DIFF
--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -178,7 +178,6 @@ class CosmozTabs extends mixinBehaviors(TabbableBehavior, PolymerElement) {
 	constructor() {
 		super();
 		this._tabPropertyChangedHandler = this._tabPropertyChanged.bind(this);
-		this._onIronResizeHandler = this._onIronResize.bind(this);
 	}
 
 	connectedCallback() {
@@ -189,10 +188,6 @@ class CosmozTabs extends mixinBehaviors(TabbableBehavior, PolymerElement) {
 	disconnectedCallback() {
 		super.disconnectedCallback();
 		this.removeEventListener('tab-property-changed', this._tabPropertyChangedHandler);
-
-		// make sure iron-resize handler is cleaned up
-		// it is not guaranteed to have been added
-		this.removeEventListener('iron-resize', this._onIronResizeHandler);
 	}
 
 	static get observers() {
@@ -269,38 +264,6 @@ class CosmozTabs extends mixinBehaviors(TabbableBehavior, PolymerElement) {
 			return;
 		}
 
-		if (this._hashReady) {
-			return;
-		}
-
-		this._updateSelectedFromHashParams();
-
-		// if the element is not visible at creation time,
-		// then read the hash again after it becomes visible
-		if (!this._isVisible) {
-			this._updateSelectedFromHashParamsDeferred();
-		}
-	}
-
-	/**
-	 * Defers the reading of the hash params until the element becomes visible
-	 *
-	 * Visibility change is determined by the element receiving an `iron-resize`
-	 * event.
-	 *
-	 * Can be called multiple times, the hash is read only once.
-	 * @return {[type]} [description]
-	 */
-	_updateSelectedFromHashParamsDeferred() {
-		this.removeEventListener('iron-resize', this._onIronResizeHandler);
-		this.addEventListener('iron-resize', this._onIronResizeHandler);
-	}
-
-	_onIronResize() {
-		// make sure this event is run only once
-		this.removeEventListener('iron-resize', this._onIronResizeHandler);
-
-		// read the selected tab from the hash
 		this._updateSelectedFromHashParams();
 	}
 
@@ -312,8 +275,6 @@ class CosmozTabs extends mixinBehaviors(TabbableBehavior, PolymerElement) {
 	 * @return {void}
 	 */
 	_updateSelectedFromHashParams() {
-		this._hashReady = true;
-
 		const value = this._normalizeValue(this.get(['_routeHashParams', this.hashParam])),
 			item = this._valueToItem(value),
 			invalid = item == null;
@@ -333,7 +294,7 @@ class CosmozTabs extends mixinBehaviors(TabbableBehavior, PolymerElement) {
 		 * @return {void}
 		 */
 	_selectedItemChanged(selected, hashParam) {
-		if (!(hashParam && this._routeHashParams && this.items.length) || !this._hashReady) {
+		if (!(hashParam && this._routeHashParams && this.items.length)) {
 			return;
 		}
 		const item = this._valueToItem(selected),

--- a/test/hash.test.js
+++ b/test/hash.test.js
@@ -33,10 +33,8 @@ suite('hash', () => {
 
 	test('updates selected item from location hash', () => {
 		flush();
-		tabs._hashReady = false; // ignore hash read in test setup to test selected update
 		window.location.hash = '##tab=tab0';
 		flush();
-		assert.isTrue(tabs._hashReady);
 		assert.equal(tabs._routeHashParams[tabs.hashParam], 'tab0');
 		assert.equal(tabs.selected, 'tab0');
 		assert.equal(tabs.selectedItem, tabs.items[0]);
@@ -44,8 +42,8 @@ suite('hash', () => {
 		window.location.hash = '##tab=tab1';
 		flush();
 		assert.equal(tabs._routeHashParams[tabs.hashParam], 'tab1', 'Expected _routeHashParams to be updated from location hash');
-		assert.equal(tabs.selected, 'tab0', 'Expected selected to remain tab0 as selected was already updated once from hash.');
-		assert.equal(tabs.selectedItem, tabs.items[0]);
+		assert.equal(tabs.selected, 'tab1');
+		assert.equal(tabs.selectedItem, tabs.items[1]);
 		window.location.hash = '#';
 	});
 
@@ -114,31 +112,6 @@ suite('hash param', () => {
 				// then the hash is read and the correct tab is displayed
 				assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
 			});
-
-			test('ignores further changes to the hash-param property', async () => {
-				// given that the page loads with multiple hash param values
-				window.location.hash = '##tab=tab2&tabx=tab1';
-
-				// when the element is created
-				// and hash-param is not set
-				const { tabs } = await createFixture();
-
-				// then the hash is ignored and first tab is selected
-				assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 0');
-
-				// when hash-param is updated
-				tabs.hashParam = 'tab';
-
-				// then the hash is read and the correct tab is displayed
-				assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
-
-				// and further changes are ignored
-				tabs.hashParam = 'tabx';
-				assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
-
-				tabs.hashParam = undefined;
-				assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
-			});
 		});
 
 		suite('and hash-param is set', () => {
@@ -166,45 +139,6 @@ suite('hash param', () => {
 
 				// then the first tab is selected
 				assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 0');
-			});
-
-			test('ignores further hash param value changes', async () => {
-				// given that the page loads with a hash param value set to the last tab
-				window.location.hash = '##tab=tab2';
-
-				// when the element is created
-				const { tabs } = await createFixture({
-					hashParam: 'tab'
-				});
-
-				// then the last tab is selected
-				assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
-
-				// when the hash param is changed to the first tab
-				window.location.hash = '##tab=tab1';
-
-				// then the last tab remains selected
-				assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
-			});
-
-			test('ignores changes to the hash-param property', async () => {
-				// given that the page loads with multiple hash param values
-				window.location.hash = '##tab=tab2&tabx=tab1';
-
-				// when the element is created
-				// and hash-param is set to 'tab
-				const { tabs } = await createFixture({
-					hashParam: 'tab'
-				});
-
-				// then the correct tab is selected
-				assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
-
-				// when hash-param is changed
-				tabs.hashParam = 'tabx';
-
-				// then the change is ignored
-				assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
 			});
 		});
 	});
@@ -245,88 +179,12 @@ suite('hash param', () => {
 
 			// when the hash param is changed to the second tab
 			window.location.hash = '##tab=tab1';
-			// then the last tab is still selected
-			assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
-			// when the element becomes visible
-			collapse.opened = true;
-
 			// then the second tab is selected
 			assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 1');
-		});
-
-		test('ignores further hash param value changes', async () => {
-			// given that the page loads with a hash param value set to the last tab
-			window.location.hash = '##tab=tab2';
-
-			// when the element is created, but is not visible
-			const {
-				tabs, collapse
-			} = await createFixture({
-				hashParam: 'tab',
-				opened: false
-			});
-
 			// when the element becomes visible
 			collapse.opened = true;
 
-			// then the last tab is selected
-			assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
-
-			// when the hash param is changed to the first tab
-			window.location.hash = '##tab=tab1';
-
-			// and the element becomes invisible, then visible again
-			collapse.opened = false;
-			collapse.opened = true;
-
-			// then the last tab remains selected
-			assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
-
-			// when the hash param is changed to the first tab
-			window.location.hash = '##tab=tab0';
-
-			// and the element becomes invisible, then visible again
-			collapse.opened = false;
-			collapse.opened = true;
-
-			// then the last tab still remains selected
-			assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 2');
-		});
-
-		test('ignores changes to the hash-param property after it is first set', async () => {
-			// given that the page loads with multiple hash param values: 'tab' and 'tabx'
-			window.location.hash = '##tab=tab2&tabx=tab1';
-
-			// when the element is created
-			// and hash-param is not set
-			// and the element is not visible
-			const {
-				tabs, collapse
-			} = await createFixture({
-				hashParam: null,
-				opened: false
-			});
-
-			// when the hash-param is updated to 'tabx'
-			tabs.hashParam = 'tabx';
-
-			// and the element becomes visible
-			collapse.opened = true;
-
-			// then the value specified by 'tabx' is selected
-			assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 1');
-
-			// when hash-param is changed to 'tab'
-			tabs.hashParam = 'tab';
-
-			// then the change is ignored
-			assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 1');
-
-			// when the element becomes invisible, then visible again
-			collapse.opened = false;
-			collapse.opened = true;
-
-			// then the change is still ignored
+			// then the second tab is still selected
 			assert.equal(tabs.querySelector('.cosmoz-selected').textContent, 'Tab text 1');
 		});
 


### PR DESCRIPTION
…changes

Previously the hashParam was updated only once; when the cosmoz-tabs element became visible. This is no longer compatible with the recent addition of `renderItem` support to cosmoz-data-nav, which does not destroy and re-render dataNav templates. Because views are re-used, the cross-queue selected tab synchronization does not work anymore.

I have tested and seen no errors caused by this change.