### PR TITLE
fix: restore hide badge on negative value #24231

### DIFF
--- a/cosmoz-tab.js
+++ b/cosmoz-tab.js
@@ -154,7 +154,7 @@ class CosmozTab extends mixinBehaviors([TabbedBehavior, TabbableBehavior, Tabbed
 		<div id="header" on-tap="_onToggleTap" part="header">
 			<iron-icon class="icon" icon="[[ getIcon(isSelected, accordion, icon, selectedIcon) ]]" style$="[[ getIconStyle(iconColor) ]]"></iron-icon>
 			<h1 class="heading">[[ heading ]]</h1>
-			<div class="badge" title$="[[ badge ]]">[[ badge ]]</div>
+			<div class="badge" hidden$="[[ !badge ]]" title$="[[ badge ]]">[[ badge ]]</div>
 			<paper-icon-button icon="[[ _computeOpenedIcon(isSelected) ]]"></paper-icon-button>
 		</div>
 

--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -114,7 +114,7 @@ class CosmozTabs extends mixinBehaviors(TabbableBehavior, PolymerElement) {
 								<iron-icon class="icon" icon="[[ _computeIcon(tab, selectedItem.isSelected) ]]"
 									style$="[[ _computeIconStyle(tab, tab.iconStyle) ]]"></iron-icon>
 								<h1 class="heading">[[ tab.heading ]]</h1>
-								<div class="badge" title$="[[ tab.badge ]]">[[ tab.badge ]]</div>
+								<div class="badge" hidden$="[[ !tab.badge ]]" title$="[[ tab.badge ]]">[[ tab.badge ]]</div>
 							</a>
 						</paper-tab>
 					</template>


### PR DESCRIPTION
Check that the badge counter is hidden when the value for the badge is 0 and that is shown if it is above 0.

RM:24231.
