### PR TITLE
fix: size tabs correctly when paper-tabs has different size

### DIFF
--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -91,9 +91,7 @@ class CosmozTabs extends mixinBehaviors(TabbableBehavior, PolymerElement) {
 				:host(:not([accordion])) #pages {
 					display: flex;
 					flex-direction: column;
-					flex: 1 1 auto;
-					max-height: 100%;
-					max-height: calc(100% - 51px);
+					flex: 1 auto;
 				}
 
 				paper-tab[hidden],

--- a/test/sizing.test.js
+++ b/test/sizing.test.js
@@ -75,47 +75,7 @@ suite('sizing', () => {
 		sinonAssert.calledOnce(onResize);
 	});
 
-	test('explicitly sized tabs and list without flex correctly update size but renders max items ', async () => {
-		const tabs = await fixture(html`
-			<cosmoz-tabs selected="tab0" style="height: 400px">
-				<cosmoz-tab name="tab0" heading="Flex">
-					<iron-list id="x-list">
-						<template>
-							<div class="item">
-								<div style="height: 100px;">[[item]]</div>
-							</div>
-						</template>
-					</iron-list>
-				</cosmoz-tab>
-				<cosmoz-tab name="tab1" heading="Content">
-					<p>
-						Etiam ante dolor, commodo non vestibulum vel, malesuada a nunc. Vestibulum accumsan,
-						sapien eu gravida consectetur, purus felis lobortis massa, id consequat eros lacus sit amet quam.
-						Nunc bibendum elit turpis. Ut et convallis quam, ut elementum enim. Aenean semper mattis enim
-						quis luctus. Vivamus libero urna, dictum non lacus a, porta consequat lacus. Etiam eu nisi diam.
-						Nam varius non ex vitae scelerisque.
-					</p>
-				</cosmoz-tab>
-			</cosmoz-tabs>`),
-			list = tabs.querySelector('iron-list'),
-			onResize = spy();
-
-		list.addEventListener('iron-resize', onResize);
-		flush();
-
-		list.items = Array.from(Array(100).keys());
-		flush();
-		tabs._debouncer.flush();
-
-		list.removeEventListener('iron-resize', onResize);
-
-		assert.equal(list.getBoundingClientRect().height, 349);
-		assert.lengthOf(list.queryAllEffectiveChildren('.item'), 100);
-
-		sinonAssert.calledOnce(onResize);
-	});
-
-	test('explicitly sized tabs with element selected and flex list renders only a few items', async () => {
+		test('explicitly sized tabs with element selected and flex list renders only a few items', async () => {
 		const tabs = await fixture(html`
 			<cosmoz-tabs selected="tab0" style="height: 400px">
 				<cosmoz-tab name="tab0" heading="Flex">

--- a/test/sizing.test.js
+++ b/test/sizing.test.js
@@ -75,7 +75,7 @@ suite('sizing', () => {
 		sinonAssert.calledOnce(onResize);
 	});
 
-		test('explicitly sized tabs with element selected and flex list renders only a few items', async () => {
+	test('explicitly sized tabs with element selected and flex list renders only a few items', async () => {
 		const tabs = await fixture(html`
 			<cosmoz-tabs selected="tab0" style="height: 400px">
 				<cosmoz-tab name="tab0" heading="Flex">


### PR DESCRIPTION
The max-height set on `#pages` in cosmoz-tabs can limit the tabs to a incorrect size when paper-tabs +margin do not have 51px in size. This happens if you zoom out  or if somehow differrent fonts and weights/sizes are used for paper-tabs ... 