### PR TITLE
fix(cosmoz-tabs): delays initial setTabs to microtask

### DIFF
--- a/lib/use-tabs.js
+++ b/lib/use-tabs.js
@@ -59,7 +59,7 @@ const useTabSelectedEffect = (host, selectedTab) => {
 		return {
 			tabs,
 			selectedTab,
-			onSlot: useCallback(({ target }) => setTabs(target.assignedElements().filter(el => el.matches('cosmoz-tab'))), []),
+			onSlot: useCallback(({ target }) => queueMicrotask(() => setTabs(target.assignedElements().filter(el => el.matches('cosmoz-tab')))), []),
 			onSelect: useCallback(e => {
 				if (e.button !== 0 || e.metaKey || e.ctrlKey) {
 					return;


### PR DESCRIPTION
In Firefox the `slotchange` fires a bit too soon ...