### PR TITLE
fix: initial "selected-changed" event is not fired

### DIFF
--- a/lib/use-tabs.js
+++ b/lib/use-tabs.js
@@ -46,6 +46,10 @@ const useTabSelectedEffect = (host, selectedTab) => {
 		useTabSelectedEffect(host, selectedTab);
 
 		useEffect(() => {
+			notifyProperty(host, 'selected', selection);
+		}, []);
+
+		useEffect(() => {
 			const onTabAlter = e => {
 				e.stopPropagation();
 				setTabs(prev => prev.slice());


### PR DESCRIPTION
This was the behaviour in Polymer and there is code that relies on it.