### PR TITLE
fix: add no-resize option in cosmoz-tabs

### DIFF
--- a/cosmoz-tabs.js
+++ b/cosmoz-tabs.js
@@ -46,5 +46,5 @@ const Tabs = host => {
 };
 
 customElements.define('cosmoz-tabs', component(Tabs, {
-	observedAttributes: ['selected', 'hash-param']
+	observedAttributes: ['selected', 'hash-param', 'no-resize']
 }));

--- a/lib/use-tabs.js
+++ b/lib/use-tabs.js
@@ -26,7 +26,9 @@ const useTabSelectedEffect = (host, selectedTab) => {
 			}
 
 			selectedTab.dispatchEvent(new CustomEvent('tab-select', opts));
-			requestAnimationFrame(() => window.dispatchEvent(new Event('resize')));
+			if (!host.noResize) {
+				requestAnimationFrame(() => window.dispatchEvent(new Event('resize')));
+			}
 			return () => {
 				selectedTab.toggleAttribute('is-selected', false);
 			};

--- a/test/cosmoz-tabs-basic.test.js
+++ b/test/cosmoz-tabs-basic.test.js
@@ -1,6 +1,7 @@
 import {
 	assert, html, fixture, nextFrame
 } from '@open-wc/testing';
+import { spy } from 'sinon';
 
 import '../cosmoz-tabs.js';
 
@@ -29,6 +30,19 @@ suite('cosmoz-tabs', () => {
 		tabs.selected = 'tab1';
 		await nextFrame();
 		assert.equal(tabs.querySelector('[is-selected]').getAttribute('name'), 'tab1');
+	});
+
+	test('does not resize on select', async () => {
+		tabs.toggleAttribute('no-resize', true);
+		await nextFrame();
+
+		const resizeSpy = spy();
+		window.addEventListener('resize', resizeSpy);
+
+		tabs.selected = 'tab1';
+		await nextFrame();
+		window.removeEventListener('resize', resizeSpy);
+		assert.isTrue(resizeSpy.notCalled);
 	});
 
 	test('contains a tablist with the same number of tabs', () => {


### PR DESCRIPTION
The no-resize option/attribute is usefull (sometimes event needed) so that we don't fire the 'resize' event to force `iron-resize` updates.