### PR TITLE
fix: read params in a animation frame

### DIFF
--- a/lib/use-hash-param.js
+++ b/lib/use-hash-param.js
@@ -21,13 +21,13 @@ const hashUrl = () => new URL(location.hash.replace(/^#!?/iu, '').replace('%23',
 			if (parameterized == null) {
 				return;
 			}
-			const updateParam = () => setParam(parameterized);
-			requestAnimationFrame(updateParam);
-			window.addEventListener('popstate', updateParam);
-			window.addEventListener('hash-changed', updateParam);
+			const readParam = () => requestAnimationFrame(() => setParam(parameterized));
+			readParam();
+			window.addEventListener('popstate', readParam);
+			window.addEventListener('hash-changed', readParam);
 			return () => {
-				window.removeEventListener('popstate', updateParam);
-				window.removeEventListener('hash-changed', updateParam);
+				window.removeEventListener('popstate', readParam);
+				window.removeEventListener('hash-changed', readParam);
 			};
 		}, [parameterized]);
 


### PR DESCRIPTION
Reads hash params in a animation frame to make sure that the render scheduler queue is ready before we request another state update. 