### PR TITLE
fix: correctly notify `selected`

### DIFF
--- a/lib/use-tabs.js
+++ b/lib/use-tabs.js
@@ -12,8 +12,11 @@ import {
 const useTabSelectedEffect = (host, selectedTab) => {
 		useEffect(() => {
 			notifyProperty(host, 'selectedItem', selectedTab);
-			if (!selectedTab) {
+			if (selectedTab == null) {
 				return;
+			}
+			if (host.selected == null) {
+				notifyProperty(host, 'selected', selectedTab.getAttribute('name'));
 			}
 			selectedTab.toggleAttribute('is-selected', true);
 			const opts = {
@@ -46,10 +49,6 @@ const useTabSelectedEffect = (host, selectedTab) => {
 			selectedTab = useMemo(() => choose(tabs, selection), [tabs, selection]);
 
 		useTabSelectedEffect(host, selectedTab);
-
-		useEffect(() => {
-			notifyProperty(host, 'selected', selection);
-		}, []);
 
 		useEffect(() => {
 			const onTabAlter = e => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2483,9 +2483,9 @@
 			}
 		},
 		"@sinonjs/samsam": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
-			"integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.2.0.tgz",
+			"integrity": "sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.6.0",
@@ -2500,9 +2500,9 @@
 			"dev": true
 		},
 		"@storybook/storybook-deployer": {
-			"version": "2.8.6",
-			"resolved": "https://registry.npmjs.org/@storybook/storybook-deployer/-/storybook-deployer-2.8.6.tgz",
-			"integrity": "sha512-Bpe7ZtsR5NUuohK3VsQa+nxEHtVxMZZo3DRlRUZW5IZOmzmvSID3i+jkizloG9xO7sw5zUvlD31YMHm7OtdrMA==",
+			"version": "2.8.7",
+			"resolved": "https://registry.npmjs.org/@storybook/storybook-deployer/-/storybook-deployer-2.8.7.tgz",
+			"integrity": "sha512-O0hKHV6hg93fPMvKGC5M/sd7KTL473+SzMKm+WZNVEyLEfXXcVU+Ts9/VL1IhmC1P2A8Bg9oBnkcPqAqjAN46w==",
 			"dev": true,
 			"requires": {
 				"git-url-parse": "^11.1.2",
@@ -16068,15 +16068,15 @@
 			}
 		},
 		"sinon": {
-			"version": "9.1.0",
-			"resolved": "https://registry.npmjs.org/sinon/-/sinon-9.1.0.tgz",
-			"integrity": "sha512-9zQShgaeylYH6qtsnNXlTvv0FGTTckuDfHBi+qhgj5PvW2r2WslHZpgc3uy3e/ZAoPkqaOASPi+juU6EdYRYxA==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.0.tgz",
+			"integrity": "sha512-eSNXz1XMcGEMHw08NJXSyTHIu6qTCOiN8x9ODACmZpNQpr0aXTBXBnI4xTzQzR+TEpOmLiKowGf9flCuKIzsbw==",
 			"dev": true,
 			"requires": {
-				"@sinonjs/commons": "^1.7.2",
+				"@sinonjs/commons": "^1.8.1",
 				"@sinonjs/fake-timers": "^6.0.1",
 				"@sinonjs/formatio": "^5.0.1",
-				"@sinonjs/samsam": "^5.1.0",
+				"@sinonjs/samsam": "^5.2.0",
 				"diff": "^4.0.2",
 				"nise": "^4.0.4",
 				"supports-color": "^7.1.0"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"@polymer/iron-list": "^3.1.0",
 		"@semantic-release/changelog": "^5.0.1",
 		"@semantic-release/git": "^9.0.0",
-		"@storybook/storybook-deployer": "^2.8.6",
+		"@storybook/storybook-deployer": "^2.8.7",
 		"deepmerge": "^4.2.2",
 		"eslint": "^7.10.0",
 		"husky": "^4.2.5",
@@ -84,7 +84,7 @@
 		"karma-firefox-launcher": "^1.3.0",
 		"karma-sauce-launcher": "^4.0.0",
 		"semantic-release": "^17.0.6",
-		"sinon": "^9.1.0",
+		"sinon": "^9.2.0",
 		"typescript": "^4.0.3"
 	}
 }

--- a/test/cosmoz-tabs-basic.test.js
+++ b/test/cosmoz-tabs-basic.test.js
@@ -24,7 +24,7 @@ suite('cosmoz-tabs', () => {
 	});
 
 	test('selects an item', async () => {
-		assert.equal(tabs.selected, undefined);
+		assert.equal(tabs.selected, 'tab0');
 		assert.equal(tabs.querySelector('[is-selected]').getAttribute('name'), 'tab0');
 
 		tabs.selected = 'tab1';
@@ -180,7 +180,7 @@ suite('cosmoz-tabs', () => {
 		hiddenTab.hidden = false;
 		await nextFrame();
 
-		assert.equal(tabs.querySelector('[is-selected]'), hiddenTab);
+		assert.equal(tabs.querySelector('[is-selected]').getAttribute('name'), hiddenTab.getAttribute('name'));
 	});
 
 	test('enabling a fallback disabled tab selects	it', async () => {

--- a/test/cosmoz-tabs-sizing.test.js
+++ b/test/cosmoz-tabs-sizing.test.js
@@ -73,7 +73,7 @@ suite('cosmoz-tabs sizing', () => {
 
 	test('explicitly sized tabs and flex list updates size and renders only a few items upon selection', async () => {
 		const tabs = await fixture(html`
-				<cosmoz-tabs style="height: 400px" fallback-selection>
+				<cosmoz-tabs style="height: 400px">
 					<cosmoz-tab name="tab0" heading="Flex">
 						<iron-list id="x-list" style="flex: 1 1 0.00000001px;">
 							<template>
@@ -96,7 +96,6 @@ suite('cosmoz-tabs sizing', () => {
 			`),
 			list = tabs.querySelector('iron-list');
 
-		assert.isUndefined(tabs.selected);
 		list.items = Array.from(Array(500).keys());
 
 		tabs.selected = 'tab0';


### PR DESCRIPTION
There was an attempt to fix `selected` notification in #126 but it was incomplete.
This restores original `cosmoz-tabs` 's `selected` notification.