### PR TITLE
fix: update children from slot in raf

### DIFF
--- a/lib/use-tabs.js
+++ b/lib/use-tabs.js
@@ -64,7 +64,7 @@ const useTabSelectedEffect = (host, selectedTab) => {
 		return {
 			tabs,
 			selectedTab,
-			onSlot: useCallback(({ target }) => queueMicrotask(() => setTabs(target.assignedElements().filter(el => el.matches('cosmoz-tab')))), []),
+			onSlot: useCallback(({ target }) => requestAnimationFrame(() => setTabs(target.assignedElements().filter(el => el.matches('cosmoz-tab')))), []),
 			onSelect: useCallback(e => {
 				if (e.button !== 0 || e.metaKey || e.ctrlKey) {
 					return;

--- a/test/cosmoz-tabs-basic.test.js
+++ b/test/cosmoz-tabs-basic.test.js
@@ -17,6 +17,7 @@ suite('cosmoz-tabs', () => {
 				<cosmoz-tab name="tab3" heading="Tab3" disabled icon="warning">3</cosmoz-tab>
 			</cosmoz-tabs>
 		`);
+		await nextFrame();
 	});
 
 	test('instantiates a cosmoz-tabs', () => {

--- a/test/cosmoz-tabs-hash.test.js
+++ b/test/cosmoz-tabs-hash.test.js
@@ -19,6 +19,7 @@ suite('cosmoz-tabs hashParam', () => {
 				<cosmoz-tab name="tab2">Tab text 3</cosmoz-tab>
 			</cosmoz-tabs>
 		`);
+		await nextFrame();
 	});
 
 	test('items have links', () => {
@@ -58,13 +59,18 @@ suite('cosmoz-tabs hashParam', () => {
 });
 
 suite('cosmoz-tabs hashParam advanced', () => {
-	const createFixture = async (opened = true, hashParam = undefined) => await fixture(html`
+	const createFixture = async (opened = true, hashParam = undefined) => {
+		const el = await fixture(html`
 			<cosmoz-tabs id="tabs" style=${ opened ? '' : 'display: none' } .selected=${ 'tab0' } .hashParam=${ hashParam } >
 				<cosmoz-tab name="tab0">Tab text 0</cosmoz-tab>
 				<cosmoz-tab name="tab1">Tab text 1</cosmoz-tab>
 				<cosmoz-tab name="tab2">Tab text 2</cosmoz-tab>
 			</cosmoz-tabs>
 		`);
+		await nextFrame();
+		return el;
+
+	};
 
 	suite('when <cosmoz-tabs> is visible at creation time', () => {
 		suite('and hash-param is not set', () => {


### PR DESCRIPTION
`slotchange` fires very fast and if polymer does a lot of updates to `cosmoz-tabs` even `queueMicrotask` (which we added for similar reasons for Firefox) is too fast to cause a re-render.