### PR TITLE
fix(use-tabs): iron-location interop

### DIFF
--- a/lib/use-tabs.js
+++ b/lib/use-tabs.js
@@ -81,6 +81,8 @@ const useTabSelectedEffect = (host, selectedTab) => {
 
 				e.preventDefault();
 				window.history.pushState({}, '', href(tab));
+				// TODO: drop this when we drop iron-location/cosmoz-page-location
+				requestAnimationFrame(() => window.dispatchEvent(new CustomEvent('location-changed')));
 				requestAnimationFrame(() => window.dispatchEvent(new CustomEvent('hash-changed')));
 			}, []),
 			href


### PR DESCRIPTION
iron-location needs to know when it should re-parse the url, otherwise components that use cosmoz-page-location will not track the url properly, leading to lost parameters.