### PR TITLE
fix(use-tabs): scroll only horizontally

### DIFF
--- a/lib/use-tabs.js
+++ b/lib/use-tabs.js
@@ -63,7 +63,7 @@ const useTabSelectedEffect = (host, selectedTab) => {
 		}, [selectedTab]);
 
 		useEffect(() => {
-			host.shadowRoot.querySelector('a[aria-selected]')?.scrollIntoView?.({ inline: 'center', behavior: 'smooth' });
+			host.shadowRoot.querySelector('a[aria-selected]')?.scrollIntoView?.({ block: 'nearest', inline: 'center', behavior: 'smooth' });
 		}, [selectedTab]);
 
 		const href = useCallback(tab => isValid(tab) ? link(hashParam, getName(tab)) : undefined, [hashParam]);


### PR DESCRIPTION
Scrolls the tabs only horizontally.
