### PR TITLE
fix(use-tabs): uses compute-scroll-into-view

### DIFF
--- a/lib/use-tabs.js
+++ b/lib/use-tabs.js
@@ -1,13 +1,8 @@
-import {
-	useState, useEffect, useMemo, useCallback
-} from 'haunted';
+import { useState, useEffect, useMemo, useCallback } from 'haunted';
 import { notifyProperty } from '@neovici/cosmoz-utils/lib/hooks/use-notify-property';
-import {
-	useHashParam, link
-} from './use-hash-param';
-import {
-	choose, collect, getName, isValid
-} from './utils';
+import { useHashParam, link } from './use-hash-param';
+import { choose, collect, getName, isValid } from './utils';
+import computeScroll from 'compute-scroll-into-view';
 
 const useTabSelectedEffect = (host, selectedTab) => {
 		useEffect(() => {
@@ -37,6 +32,17 @@ const useTabSelectedEffect = (host, selectedTab) => {
 		}, [selectedTab]);
 	},
 
+	useAutoScroll = (host, selectedTab) => {
+		useEffect(() => {
+			const el = host.shadowRoot.querySelector('a[aria-selected]');
+			if (!el) {
+				return;
+			}
+			computeScroll(el, { block: 'nearest', inline: 'center', boundary: el.parentElement })
+				.forEach(({ el, top, left }) => el.scroll({ top, left, behavior: 'smooth' }));
+		}, [selectedTab]);
+	},
+
 	useTabs = host => {
 		const {
 				selected, hashParam
@@ -62,9 +68,7 @@ const useTabSelectedEffect = (host, selectedTab) => {
 			return () => host.removeEventListener('cosmoz-tab-alter', onTabAlter);
 		}, [selectedTab]);
 
-		useEffect(() => {
-			host.shadowRoot.querySelector('a[aria-selected]')?.scrollIntoView?.({ block: 'nearest', inline: 'center', behavior: 'smooth' });
-		}, [selectedTab]);
+		useAutoScroll(host, selectedTab);
 
 		const href = useCallback(tab => isValid(tab) ? link(hashParam, getName(tab)) : undefined, [hashParam]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 				"@neovici/cosmoz-utils": "^3.21.0",
 				"@polymer/iron-icon": "^3.0.0",
 				"@polymer/iron-icons": "^3.0.0",
+				"compute-scroll-into-view": "^1.0.17",
 				"haunted": "^4.8.0",
 				"lit-html": "^1.4.0"
 			},
@@ -5670,6 +5671,11 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/compute-scroll-into-view": {
+			"version": "1.0.17",
+			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+			"integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
@@ -23037,6 +23043,11 @@
 			"requires": {
 				"mime-db": ">= 1.43.0 < 2"
 			}
+		},
+		"compute-scroll-into-view": {
+			"version": "1.0.17",
+			"resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.17.tgz",
+			"integrity": "sha512-j4dx+Fb0URmzbwwMUrhqWM2BEWHdFGx+qZ9qqASHRPqvTYdqvWnHg0H1hIbcyLnvgnoNAVMlwkepyqM3DaIFUg=="
 		},
 		"concat-map": {
 			"version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
 		"@neovici/cosmoz-utils": "^3.21.0",
 		"@polymer/iron-icon": "^3.0.0",
 		"@polymer/iron-icons": "^3.0.0",
+		"compute-scroll-into-view": "^1.0.17",
 		"haunted": "^4.8.0",
 		"lit-html": "^1.4.0"
 	},


### PR DESCRIPTION
Replaces calls to scrollIntoVIew with the `compute-scroll-into-view`
module with `boundary` support.
