### PR TITLE
feat: support for cosmoz-tab-cards nested in other elements

### DIFF
--- a/src/use-tab.js
+++ b/src/use-tab.js
@@ -25,7 +25,7 @@ const useTab = (host) => {
 			({ target }) =>
 				host.toggleAttribute(
 					'has-cards',
-					target.assignedElements().some((el) => el.matches('cosmoz-tab-card'))
+					target.assignedElements().some((el) => el.matches('cosmoz-tab-card, [has-cards]'))
 				),
 			[]
 		),


### PR DESCRIPTION
I want to make code like this work:

```html
<cosmoz-tab
    heading="[[ _('Executive summary', t) ]]"
    name="executive-summary"
    has-briefs
>
    <executive-summary-tab has-cards invoice="[[_invoice]]"></executive-summary-tab>
</cosmoz-tab>
```

`executive-summary-tab` is a component without shadowRoot. It contains `cosmoz-tab-cards` and it has `display: contents`.