### PR TITLE
feat(cosmoz-tab-card): added vars for styling with new color palettes

### DIFF
--- a/src/cosmoz-tab-card.js
+++ b/src/cosmoz-tab-card.js
@@ -1,8 +1,5 @@
 // @license Copyright (C) 2015 Neovici AB - Apache 2 License
-import {
-	html,
-	component
-} from 'haunted';
+import { html, component } from 'haunted';
 
 /**
 
@@ -21,53 +18,61 @@ Custom property                         | Description              | Default
 `--cosmoz-tab-card-padding`             | Card padding             | `0`
 `--cosmoz-tab-card-content-line-height` | Card content line height | `initial`
 `--cosmoz-tab-card-content-padding`     | Card content padding     | `initial`
+`--cosmoz-tab-card-bg-color`            | Card background color    | `white`
 */
-const CosmozTabCard = ({ heading }) => html`
-<style>
-	:host {
-		display: block;
-		position: relative;
-		box-sizing: border-box;
-		background-color: #fff;
-		border-radius: 3px;
-		margin: 15px;
-		align-self: flex-start;
-		padding: var(--cosmoz-tab-card-padding, 0);
-		width: var(--cosmoz-tab-card-width, 300px);
-		box-shadow: var(--cosmoz-shadow-2dp, var(--shadow-elevation-2dp_-_box-shadow, 0 2px 4px 0 #e5e5e5));
-	}
+const CosmozTabCard = ({ heading }) => html` <style>
+		:host {
+			display: block;
+			position: relative;
+			box-sizing: border-box;
+			background-color: var(--cosmoz-tab-card-bg-color, white);
+			border-radius: 3px;
+			margin: 15px;
+			align-self: flex-start;
+			padding: var(--cosmoz-tab-card-padding, 0);
+			width: var(--cosmoz-tab-card-width, 300px);
+			box-shadow: var(
+				--cosmoz-shadow-2dp,
+				var(--shadow-elevation-2dp_-_box-shadow, 0 2px 4px 0 #e5e5e5)
+			);
+		}
 
-	#content {
-		line-height: var(--cosmoz-tab-card-content-line-height, initial);
-		padding: var(--cosmoz-tab-card-content-padding, initial);
-	}
+		#content {
+			line-height: var(--cosmoz-tab-card-content-line-height, initial);
+			padding: var(--cosmoz-tab-card-content-padding, initial);
+		}
 
-	#header {
-		display: flex;
-		align-items: center;
-		background-color: #fff;
-		cursor: default;
-		-webkit-tap-highlight-color: rgba(0,0,0,0);
-	}
+		#header {
+			display: flex;
+			align-items: center;
+			background-color: var(--cosmoz-tab-card-bg-color, white);
+			cursor: default;
+			-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+		}
 
-	.heading {
-		font-family: inherit;
-		font-size: 17px;
-		font-weight: 400;
-		flex: 1;
-		margin: 0.67em 0 0;
-	}
-</style>
+		.heading {
+			font-family: inherit;
+			font-size: 17px;
+			font-weight: 400;
+			flex: 1;
+			margin: 0.67em 0 0;
+		}
+	</style>
 
-<div id="header" part="header">
-	<h1 class="heading" part="heading">${ heading }<slot name="after-title"></slot></h1>
-	<slot name="card-actions"></slot>
-</div>
+	<div id="header" part="header">
+		<h1 class="heading" part="heading">
+			${heading}<slot name="after-title"></slot>
+		</h1>
+		<slot name="card-actions"></slot>
+	</div>
 
-<div id="content" part="content">
-	<slot></slot>
-</div>`;
+	<div id="content" part="content">
+		<slot></slot>
+	</div>`;
 
-customElements.define('cosmoz-tab-card', component(CosmozTabCard, {
-	observedAttributes: ['heading']
-}));
+customElements.define(
+	'cosmoz-tab-card',
+	component(CosmozTabCard, {
+		observedAttributes: ['heading'],
+	})
+);


### PR DESCRIPTION
Feature [AB#12608](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/12608) - the tab card background color is linked to a variable, therefore it will be possible to style it directly in frontend via variables
