### PR TITLE
fix(cosmoz-tab-card): fix sizing

### DIFF
--- a/src/cosmoz-tab-card.js
+++ b/src/cosmoz-tab-card.js
@@ -90,6 +90,7 @@ const style = css`
 
 	.collapse {
 		display: flex;
+		flex-direction: column;
 		flex: auto;
 	}
 


### PR DESCRIPTION
Fix cosmoz-tab-card sizing by always filling the width. 