### PR TITLE
feat(bg-color): bg color manageable from the outside via css vars

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,6 @@
 {
 	"eslint.validate": [ "javascript" ],
 	"editor.codeActionsOnSave": {
-		"source.fixAll.eslint": true
+		"source.fixAll.eslint": "explicit"
 	}
 }

--- a/src/cosmoz-tab-card.js
+++ b/src/cosmoz-tab-card.js
@@ -56,7 +56,7 @@ const CosmozTabCard = (host) => {
 					>
 						<slot name="collapse-icon">${collapseIcon}</slot>
 					</div>
-				`,
+				`
 			)}
 			<h1 class="heading" @click=${toggleCollapsed} part="heading">
 				${heading}<slot name="after-title"></slot>
@@ -104,7 +104,7 @@ const style = css`
 		display: flex;
 		align-items: center;
 		gap: 8px;
-		background-color: #fff;
+		background-color: var(--cosmoz-tab-card-bg-color, white);
 		-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 	}
 
@@ -137,5 +137,5 @@ customElements.define(
 	component(CosmozTabCard, {
 		observedAttributes: ['heading', 'collapsable', 'collapsed'],
 		styleSheets: [style],
-	}),
+	})
 );

--- a/src/cosmoz-tab-card.js
+++ b/src/cosmoz-tab-card.js
@@ -76,7 +76,7 @@ const style = css`
 		display: block;
 		position: relative;
 		box-sizing: border-box;
-		background-color: #fff;
+		background-color: var(--cosmoz-tab-card-bg-color, white);
 		border-radius: 3px;
 		margin: 15px;
 		align-self: flex-start;


### PR DESCRIPTION
[AB#12608](https://dev.azure.com/neovici/7e94365d-32b1-416f-854b-7f195da31da6/_workitems/edit/12608) - remake of a [previous PR](https://github.com/Neovici/cosmoz-tabs/pull/198) whose rebase was proving too tricky