### PR TITLE
fix: badge font-family

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -80,7 +80,7 @@ const style = `
 }
 
 .badge {
-	font-family: var(--cosmoz-font-base, "Verdana, Arial, sans-serif");
+	font-family: var(--cosmoz-tabs-badge-font-family, var(--cosmoz-font-base, inherit))
 	font-weight: normal;
 	font-size: 11px;
 	line-height: 1;


### PR DESCRIPTION
cosmoz-tabs-badge-font-family variable will now fallback to cosmoz-font-base that will fallback to inherit