### PR TITLE
fix: make sure badge is rendered in cosmoz-tabs-next

### DIFF
--- a/src/next/use-tabs.js
+++ b/src/next/use-tabs.js
@@ -58,6 +58,7 @@ export const renderTabs = ({ tabs, active, onActivate, className }) =>
 			?active=${active.name === tab.name}
 			?hidden=${tab.hidden}
 			?disabled=${tab.disabled}
+			.badge=${tab.badge}
 			@click=${onActivate}
 			>${tab.content ?? title}</cosmoz-tab-next
 		>`;


### PR DESCRIPTION
Makes sure badge is rendered in cosmoz-tabs-next