### PR TITLE
fix: ignore codecov uploader artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@ yarn-error.log
 .eslintcache
 .DS_Store
 .idea
+
+# Codecov uploader artifacts
+codecov
+codecov.SHA256SUM
+codecov.SHA256SUM.sig
 .npmrc
 codecov
 codecov.SHA256SUM


### PR DESCRIPTION
Fixes FE-864

The foundry reusable workflow downloads the codecov uploader binary and signature files into the repo root. These untracked artifacts were being committed by the changeset release bot.

This adds the codecov artifacts to .gitignore:
- codecov (binary)
- codecov.SHA256SUM
- codecov.SHA256SUM.sig