### PR TITLE
chore: bump playwright to 1.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@neovici/cosmoz-tabs",
-	"version": "9.3.3",
+	"version": "9.3.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@neovici/cosmoz-tabs",
-			"version": "9.3.3",
+			"version": "9.3.4",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@neovici/cosmoz-collapse": "^1.5.0",
@@ -24,7 +24,7 @@
 				"@commitlint/config-conventional": "^19.2.2",
 				"@neovici/cfg": "^2.8.0",
 				"@open-wc/testing": "^4.0.0",
-				"@playwright/test": "^1.60.0",
+				"@playwright/test": "1.60.0",
 				"@polymer/iron-list": "^3.1.0",
 				"@storybook/addon-essentials": "^7.6.19",
 				"@storybook/addon-links": "^7.6.19",
@@ -1093,6 +1093,16 @@
 			},
 			"engines": {
 				"node": ">=v18"
+			}
+		},
+		"node_modules/@conventional-changelog/template": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.0.tgz",
+			"integrity": "sha512-12qHxvlKjHmP0PQ+17EREgC7lWyLwbph1RKcZQZ7k7ZWGmrxfxC9gadHGfvzr0g0u8BhiBGg3tks93txodlyRQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -2656,16 +2666,63 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.61.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-			"integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+			"integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"playwright": "1.61.1"
+				"playwright": "1.60.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@playwright/test/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/@playwright/test/node_modules/playwright": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.60.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/@playwright/test/node_modules/playwright-core": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
 			},
 			"engines": {
 				"node": ">=18"
@@ -8637,6 +8694,53 @@
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@web/test-runner-playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
+		"node_modules/@web/test-runner-playwright/node_modules/playwright": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+			"integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.60.0"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/@web/test-runner-playwright/node_modules/playwright-core": {
+			"version": "1.60.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@webcomponents/shadycss": {
 			"version": "1.11.2",
 			"resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.11.2.tgz",
@@ -10091,16 +10195,16 @@
 			}
 		},
 		"node_modules/conventional-changelog-conventionalcommits": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-7.0.2.tgz",
-			"integrity": "sha512-NKXYmMR/Hr1DevQegFB4MwfM5Vv0m4UIxKZTTYuD98lpTknaZlSRrDOG4X7wIXpGkfsYxZTghUN+Qq+T0YQI7w==",
+			"version": "10.2.0",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.0.tgz",
+			"integrity": "sha512-UtlM9GqolY7OmlQh5L/UEVoKsTUpTgUVy1PU8JN5gl5Ydaejb7WRklGliG1SKPxxj7hzA173eG3Kt5fYWE2pmg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
-				"compare-func": "^2.0.0"
+				"@conventional-changelog/template": "^1.2.0"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=22"
 			}
 		},
 		"node_modules/conventional-commits-parser": {
@@ -16719,53 +16823,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/playwright": {
-			"version": "1.61.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"playwright-core": "1.61.1"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"node_modules/playwright-core": {
-			"version": "1.61.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"playwright-core": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/playwright/node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/polished": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
 		"@commitlint/config-conventional": "^19.2.2",
 		"@neovici/cfg": "^2.8.0",
 		"@open-wc/testing": "^4.0.0",
-		"@playwright/test": "^1.60.0",
+		"@playwright/test": "1.60.0",
 		"@polymer/iron-list": "^3.1.0",
 		"@storybook/addon-essentials": "^7.6.19",
 		"@storybook/addon-links": "^7.6.19",
@@ -94,5 +94,8 @@
 		"sinon": "^18.0.0",
 		"storybook": "^10.2.0",
 		"typescript": "^5.4.5"
+	},
+	"overrides": {
+		"conventional-changelog-conventionalcommits": ">= 8.0.0"
 	}
 }


### PR DESCRIPTION
Pin `@playwright/test` to exact version `1.60.0` to avoid browser version mismatches when running `@vitest/browser-playwright`.\n\nRelates to FE-879